### PR TITLE
Initialize MDC Console backend prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,26 @@
-# testcodex
-A repository for me to get hands on with Codex
+# MDC Console Prototype
+
+This repository contains a simple prototype for the **MDC Console** backend. The
+backend is written in Go and exposes placeholder API endpoints for user
+registration, license activation, and provisioning of DataOS instances and
+dataplanes. It does not yet integrate with an OIDC provider, but the structure
+is ready for integration with [goauthentik/authentik](https://github.com/goauthentik/authentik).
+
+```
+POST /signup       - register a user
+POST /license      - activate a license key
+POST /instances    - create a DataOS instance (placeholder)
+GET  /instances    - list created instances
+POST /dataplanes   - create a dataplane (placeholder)
+GET  /dataplanes   - list created dataplanes
+```
+
+Run the server:
+
+```bash
+cd backend
+go run main.go
+```
+
+The `frontend` directory is currently empty and will contain the React/Ant
+Design client in a separate repository.

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/mdc-console-backend
+
+go 1.23.8

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+)
+
+// placeholder memory store
+var instances = make([]string, 0)
+var dataplanes = make([]string, 0)
+
+func main() {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/signup", signupHandler)
+	mux.HandleFunc("/license", licenseHandler)
+	mux.HandleFunc("/instances", instancesHandler)
+	mux.HandleFunc("/dataplanes", dataplanesHandler)
+
+	log.Println("Starting server on :8080")
+	log.Fatal(http.ListenAndServe(":8080", mux))
+}
+
+func signupHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	// OIDC registration would happen here
+	w.WriteHeader(http.StatusCreated)
+}
+
+func licenseHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	// validate license key (placeholder)
+	w.WriteHeader(http.StatusOK)
+}
+
+func instancesHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		// create instance placeholder
+		instances = append(instances, "instance")
+		w.WriteHeader(http.StatusAccepted)
+	case http.MethodGet:
+		json.NewEncoder(w).Encode(instances)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func dataplanesHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		// create dataplane placeholder
+		dataplanes = append(dataplanes, "dataplane")
+		w.WriteHeader(http.StatusAccepted)
+	case http.MethodGet:
+		json.NewEncoder(w).Encode(dataplanes)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// Example of OIDC verifier setup
+// oidcVerifier would initialize an OIDC provider and verifier using authentik.
+// In this skeleton implementation, it is left as a placeholder.
+func oidcVerifier() {
+	// TODO: integrate authentik OIDC verifier
+}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,3 @@
+# MDC Console Frontend
+
+This directory is reserved for the React frontend built with Ant Design. The frontend lives in a separate repository, but this placeholder outlines where the code would reside.


### PR DESCRIPTION
## Summary
- scaffold backend with Go and placeholder API routes
- add placeholder README for frontend repo
- document available endpoints

## Testing
- `gofmt -w main.go`
- `go build -x ./...` *(fails: process hung)*

------
https://chatgpt.com/codex/tasks/task_e_68417b243e0c8333b5c716c9ae19d0e7