### PR TITLE
Add in-memory tenant and provisioning handlers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,29 @@
-# testcodex
-A repository for me to get hands on with Codex
+# MDC Console Prototype
+
+This repository contains a simple prototype for the **MDC Console** backend. The
+backend is written in Go and exposes placeholder API endpoints for user
+registration, tenant management, license activation, and provisioning of DataOS
+instances and dataplanes. It stores data in memory for now and does not yet
+integrate with an OIDC provider, but the structure is ready for integration with
+[goauthentik/authentik](https://github.com/goauthentik/authentik).
+
+```
+POST /signup       - register a user
+POST /license      - activate a license key
+POST /tenants      - create a tenant ("MDC Account")
+GET  /tenants      - list tenants
+POST /instances    - create a DataOS instance
+GET  /instances    - list created instances
+POST /dataplanes   - create a dataplane
+GET  /dataplanes   - list created dataplanes
+```
+
+Run the server:
+
+```bash
+cd backend
+go run main.go
+```
+
+The `frontend` directory is currently empty and will contain the React/Ant
+Design client in a separate repository.

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,0 +1,3 @@
+module github.com/example/mdc-console-backend
+
+go 1.23.8

--- a/backend/main.go
+++ b/backend/main.go
@@ -1,0 +1,145 @@
+package main
+
+import (
+	"encoding/json"
+	"log"
+	"net/http"
+	"sync"
+)
+
+// placeholder memory store using simple structs
+type Tenant struct {
+	ID   int    `json:"id"`
+	Name string `json:"name"`
+}
+
+type Instance struct {
+	ID       int    `json:"id"`
+	Name     string `json:"name"`
+	Region   string `json:"region"`
+	TenantID int    `json:"tenant_id"`
+}
+
+type Dataplane struct {
+	ID       int    `json:"id"`
+	Name     string `json:"name"`
+	Region   string `json:"region"`
+	TenantID int    `json:"tenant_id"`
+}
+
+var (
+	tenants     = make([]Tenant, 0)
+	instances   = make([]Instance, 0)
+	dataplanes  = make([]Dataplane, 0)
+	mu          sync.Mutex
+	tenantID    = 1
+	instanceID  = 1
+	dataplaneID = 1
+)
+
+func main() {
+	mux := http.NewServeMux()
+
+	mux.HandleFunc("/signup", signupHandler)
+	mux.HandleFunc("/license", licenseHandler)
+	mux.HandleFunc("/tenants", tenantsHandler)
+	mux.HandleFunc("/instances", instancesHandler)
+	mux.HandleFunc("/dataplanes", dataplanesHandler)
+
+	log.Println("Starting server on :8080")
+	log.Fatal(http.ListenAndServe(":8080", mux))
+}
+
+func signupHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	// OIDC registration would happen here
+	w.WriteHeader(http.StatusCreated)
+}
+
+func licenseHandler(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+	// validate license key (placeholder)
+	w.WriteHeader(http.StatusOK)
+}
+
+func instancesHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		var in Instance
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		in.ID = instanceID
+		instanceID++
+		instances = append(instances, in)
+		mu.Unlock()
+		w.WriteHeader(http.StatusAccepted)
+	case http.MethodGet:
+		mu.Lock()
+		defer mu.Unlock()
+		json.NewEncoder(w).Encode(instances)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func dataplanesHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		var dp Dataplane
+		if err := json.NewDecoder(r.Body).Decode(&dp); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		dp.ID = dataplaneID
+		dataplaneID++
+		dataplanes = append(dataplanes, dp)
+		mu.Unlock()
+		w.WriteHeader(http.StatusAccepted)
+	case http.MethodGet:
+		mu.Lock()
+		defer mu.Unlock()
+		json.NewEncoder(w).Encode(dataplanes)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+func tenantsHandler(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodPost:
+		var t Tenant
+		if err := json.NewDecoder(r.Body).Decode(&t); err != nil {
+			http.Error(w, "bad request", http.StatusBadRequest)
+			return
+		}
+		mu.Lock()
+		t.ID = tenantID
+		tenantID++
+		tenants = append(tenants, t)
+		mu.Unlock()
+		w.WriteHeader(http.StatusCreated)
+	case http.MethodGet:
+		mu.Lock()
+		defer mu.Unlock()
+		json.NewEncoder(w).Encode(tenants)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// Example of OIDC verifier setup
+// oidcVerifier would initialize an OIDC provider and verifier using authentik.
+// In this skeleton implementation, it is left as a placeholder.
+func oidcVerifier() {
+	// TODO: integrate authentik OIDC verifier
+}

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,0 +1,3 @@
+# MDC Console Frontend
+
+This directory is reserved for the React frontend built with Ant Design. The frontend lives in a separate repository, but this placeholder outlines where the code would reside.


### PR DESCRIPTION
## Summary
- update README with new endpoints
- store tenants, instances and dataplanes in memory
- implement create/list handlers for tenants, instances, and dataplanes

## Testing
- `go build ./...`

------
https://chatgpt.com/codex/tasks/task_e_68417b243e0c8333b5c716c9ae19d0e7