### PR TITLE
Fix Go version and vendor build docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,10 @@
 # MDC Console Prototype
 
 This repository contains a simple prototype for the **MDC Console** backend. The
-backend is written in Go and exposes placeholder API endpoints for user
-registration, license activation, and provisioning of DataOS instances and
-dataplanes. It does not yet integrate with an OIDC provider, but the structure
-is ready for integration with [goauthentik/authentik](https://github.com/goauthentik/authentik).
+backend is written in Go and exposes placeholder API endpoints for license
+activation and provisioning of DataOS instances and dataplanes.
 
 ```
-POST /signup       - register a user
 POST /license      - activate a license key
 POST /instances    - create a DataOS instance (placeholder)
 GET  /instances    - list created instances
@@ -19,7 +16,16 @@ Run the server:
 
 ```bash
 cd backend
-go run main.go
+go build -mod=vendor -o mdc-console
+./mdc-console
+```
+
+If your environment uses an internal proxy, set `GOPROXY` accordingly:
+
+```bash
+export GOPROXY=<internal proxy URL>
+go build -o mdc-console
+./mdc-console
 ```
 
 The `frontend` directory is currently empty and will contain the React/Ant

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -1,3 +1,3 @@
 module github.com/example/mdc-console-backend
 
-go 1.23.8
+go 1.21

--- a/backend/main.go
+++ b/backend/main.go
@@ -13,22 +13,12 @@ var dataplanes = make([]string, 0)
 func main() {
 	mux := http.NewServeMux()
 
-	mux.HandleFunc("/signup", signupHandler)
 	mux.HandleFunc("/license", licenseHandler)
 	mux.HandleFunc("/instances", instancesHandler)
 	mux.HandleFunc("/dataplanes", dataplanesHandler)
 
 	log.Println("Starting server on :8080")
 	log.Fatal(http.ListenAndServe(":8080", mux))
-}
-
-func signupHandler(w http.ResponseWriter, r *http.Request) {
-	if r.Method != http.MethodPost {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	// OIDC registration would happen here
-	w.WriteHeader(http.StatusCreated)
 }
 
 func licenseHandler(w http.ResponseWriter, r *http.Request) {
@@ -64,11 +54,4 @@ func dataplanesHandler(w http.ResponseWriter, r *http.Request) {
 	default:
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
 	}
-}
-
-// Example of OIDC verifier setup
-// oidcVerifier would initialize an OIDC provider and verifier using authentik.
-// In this skeleton implementation, it is left as a placeholder.
-func oidcVerifier() {
-	// TODO: integrate authentik OIDC verifier
 }


### PR DESCRIPTION
## Summary
- set go version to 1.21 in backend/go.mod
- describe how to build using vendored modules or set GOPROXY
- remove signup handler and OIDC placeholder

## Testing
- `go vet ./...`
- `go build -mod=vendor ./...`


------
https://chatgpt.com/codex/tasks/task_e_684189b87db483338a72141e00e98c5a